### PR TITLE
Send Beeper API logout request on sign out

### DIFF
--- a/app/api/beeper/logout/route.ts
+++ b/app/api/beeper/logout/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+    const { beeperToken } = await req.json();
+
+    if (!beeperToken) {
+        return NextResponse.json({ error: "Missing beeperToken" }, { status: 400 });
+    }
+
+    const response = await fetch("https://matrix.beeper.com/_matrix/client/v3/logout", {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${beeperToken}`,
+            "Content-Type": "application/json",
+        },
+    });
+
+    if (!response.ok) {
+        let details = "";
+        try {
+            details = JSON.stringify(await response.json());
+        } catch {
+            details = await response.text();
+        }
+
+        return NextResponse.json(
+            { error: "Failed to logout from Beeper API", details },
+            { status: response.status }
+        );
+    }
+
+    return NextResponse.json({ success: true });
+}

--- a/app/components/Console.tsx
+++ b/app/components/Console.tsx
@@ -11,9 +11,21 @@ export default function Console({ beeperToken, flyToken }: any) {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState("");
 
-    function signOut() {
-        window.localStorage.clear()
-        location.reload();
+    async function signOut() {
+        try {
+            await fetch("/api/beeper/logout", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ beeperToken }),
+            });
+        } catch (error) {
+            console.error("Failed to logout from Beeper API:", error);
+        } finally {
+            window.localStorage.clear()
+            location.reload();
+        }
     }
 
     function handleBridgeDelete() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new server route at `POST /api/beeper/logout` that forwards the user token to Beeper Matrix logout (`/_matrix/client/v3/logout`)
- update the Console sign-out handler to call that route before clearing local storage
- keep local logout behavior reliable by clearing storage/reloading in a `finally` block even if the API request fails

## Testing
- `yarn build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cd2d65f-7073-4859-ba68-91de606ac258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cd2d65f-7073-4859-ba68-91de606ac258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

