### PR TITLE
Fix Docker workflow to publish to GHCR using built-in GitHub context

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,31 +4,36 @@ on:
   push:
     branches:
       - main
+
 env:
-  CI_REGISTRY_IMAGE: "${{ secrets.CI_REGISTRY }}/self-host-web"
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
 
 jobs:
   build-docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ secrets.CI_REGISTRY }}
-          username: ${{ secrets.CI_REGISTRY_USER }}
-          password: ${{ secrets.CI_REGISTRY_PASSWORD }}
+      - uses: actions/checkout@v4
 
-      - name: Docker Build
-        uses: docker/build-push-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          cache-from: ${{ env.CI_REGISTRY_IMAGE }}:latest
-          pull: true
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
           file: Dockerfile
-          tags: ${{ env.CI_REGISTRY_IMAGE }}:${{ github.sha }}
+          pull: true
           push: true
-      - uses: beeper/docker-retag-push-latest@main
-        with:
-          image: ${{ env.CI_REGISTRY_IMAGE }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
### Motivation
- Ensure the CI workflow publishes container images to GitHub Container Registry using the repository `owner/repo` format via `ghcr.io/${{ github.repository }}` so images map to the correct repo.
- Remove reliance on unassigned or custom secrets and variables and use only GitHub-provided context and secrets for seamless out-of-the-box publishing.
- Simplify and modernize the workflow by using current action majors and eliminating an extra retag step.

### Description
- Set `IMAGE_NAME` to `ghcr.io/${{ github.repository }}` and removed the prior `CI_REGISTRY` based variable.
- Replaced DockerHub login with GitHub Container Registry login using `docker/login-action@v3` and `username: ${{ github.actor }}` plus `password: ${{ secrets.GITHUB_TOKEN }}`.
- Added required job `permissions` (`contents: read`, `packages: write`) to allow GHCR pushes.
- Updated action versions to `actions/checkout@v4`, `docker/setup-buildx-action@v3`, and `docker/build-push-action@v6`, and configured `build-push-action` to push both `${{ github.sha }}` and `latest` tags directly, removing the separate retag step.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90885a0c0832ab86c1739f12bb8f2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image publishing to GitHub Container Registry
  * Modernized CI/CD workflow with latest GitHub Actions versions
  * Simplified build and deployment process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->